### PR TITLE
fix memory leaks

### DIFF
--- a/src/directives.js
+++ b/src/directives.js
@@ -420,6 +420,9 @@ angular.module('oi.select')
                 resetMatches();
 
                 element[0].addEventListener('click', click, true); //triggered before add or delete item event
+                scope.$on('$destroy', function() {
+                  element[0].removeEventListener('click', click, true);
+                });
                 element.on('focus', focus);
                 element.on('blur', blur);
 

--- a/src/services.js
+++ b/src/services.js
@@ -140,7 +140,7 @@ angular.module('oi.select')
         }
 
         return function () {
-            $document[0].removeEventListener('click', clickHandler);
+            $document[0].removeEventListener('click', clickHandler, true);
             element[0].removeEventListener('mousedown', mousedownHandler, true);
             element[0].removeEventListener('blur', blurHandler, true);
             inputElement.off('focus', focusHandler);


### PR DESCRIPTION
This fixes two memory leaks.

The first one (click) usually leaked a scope, and so everything else as well.

The second one (clickHandler) was not so drastic but leaked some detached dom elements. Note that 'removeEventListener' did not work without the third 'useCapture' parameter (http://www.w3schools.com/jsref/met_element_removeeventlistener.asp)